### PR TITLE
Rename config options to meet coding standard while keeping backward compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 yarn.lock
 .idea
+composer.lock

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ Update database afterwards.
     ```yaml
     huh_video:
         # Enable support for news entity.
-        enableNewsSupport:    false
+        enable_news_support:    false
         # Enable if by default no cookie embed urls should be used, if supported by the video provider. This can be overwritten on root pages.
-        defaultEnableNoCookieVideoUrl: false
+        default_use_no_cookie_video_url: false
         # Enable if by default a privacy message should be displayed before playing the video. This can be overwritten on root pages.
-        defaultEnablePrivacyNotice: false
+        default_display_privacy_notice: false
     ```
 1. Clear cache and check for database updates after update your config
 1. Adjust template settings on root page if needed. You can also overwrite the default configuration there.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,17 +2,28 @@
 
 This document contains informations about migrating from older versions or predecessor of this bundle.
 
+## From 0.8.x
+
+Renamed configuration options to meet coding standards. 
+
+Old | New
+--- | ---
+enableNewsSupport | enable_news_support
+defaultEnableNoCookieVideoUrl | default_use_no_cookie_video_url
+defaultEnablePrivacyNotice | default_display_privacy_notice
+videoProvider | video_provider
+
 ## From contao-youtube-bundle
 
 tl_page:
 
-Alt | Neu
+Old | New
 --- | ---
 youtubePrivacy | enableNoCookieVideoUrl
 ytShowRelated | videoShowRelated
 
 tl_content:
 
-Alt | Neu
+Old | New
 --- | ---
 youtubeFullSize | videoFullSize

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,14 +4,14 @@
 huh_video:
 
     # Enable support for news entity.
-    enableNewsSupport:    false
+    enable_news_support:    false
 
     # Enable if by default no cookie embed urls should be used, if supported by the video provider. This can be overwritten on root pages.
-    defaultEnableNoCookieVideoUrl: false
+    default_use_no_cookie_video_url: false
 
     # Enable if by default a privacy message should be displayed before playing the video. This can be overwritten on root pages.
-    defaultEnablePrivacyNotice: false
-    videoProvider:
+    default_display_privacy_notice: false
+    video_provider:
 
         # Prototype
         name:

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -45,7 +45,16 @@ huh.video.privacy.cancel | User canceled privacy prompt
 
 1. Add video translations within `huh_video.video.youtube`
 
-1. Register the video class within `huh_video.videoProvider.[videoprovider].class`
+1. Register the video class within `huh_video.video_provider.[videoprovider].class`
+
+    Example: 
+    
+    ```yaml
+    huh_video:
+      video_provider:
+        my_custom_provider:
+          class: App\Video\MyCustomProviderVideo
+    ```
 
 ## Add video support to custom entity
 

--- a/src/Collection/VideoProviderCollection.php
+++ b/src/Collection/VideoProviderCollection.php
@@ -32,8 +32,8 @@ class VideoProviderCollection
      */
     public function getVideoProvider()
     {
-        if (isset($this->bundleConfig['videoProvider'])) {
-            return array_keys($this->bundleConfig['videoProvider']);
+        if (isset($this->bundleConfig['video_provider'])) {
+            return array_keys($this->bundleConfig['video_provider']);
         }
     }
 
@@ -42,8 +42,8 @@ class VideoProviderCollection
      */
     public function getClassByVideoProvider(string $provider): string
     {
-        if (isset($this->bundleConfig['videoProvider'][$provider]['class'])) {
-            return $this->bundleConfig['videoProvider'][$provider]['class'];
+        if (isset($this->bundleConfig['video_provider'][$provider]['class'])) {
+            return $this->bundleConfig['video_provider'][$provider]['class'];
         }
 
         throw new \Exception('No configuration exists for given provider.');

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -20,21 +20,33 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('huh_video');
+
         $rootNode
             ->children()
-                ->booleanNode('enableNewsSupport')->defaultFalse()->info('Enable support for news entity. Needs database update after enable.')->end()
-                ->booleanNode('defaultEnableNoCookieVideoUrl')->defaultFalse()->info('Enable if by default no cookie embed urls should be used, if supported by the video provider. This can be overwritten on root pages.')->end()
-                ->booleanNode('defaultEnablePrivacyNotice')->defaultFalse()->info('Enable if by default a privacy message should be displayed before playing the video. This can be overwritten on root pages.')->end()
-                ->arrayNode('videoProvider')
+                ->booleanNode('enableNewsSupport')->defaultFalse()->setDeprecated('Option was renamed and will be removed in Version 1.0. Use enable_news_support instead.')->end()
+            ->booleanNode('defaultEnableNoCookieVideoUrl')->defaultFalse()->setDeprecated('Option was renamed and will be removed in Version 1.0. Use default_use_no_cookie_video_url instead.')->end()
+            ->booleanNode('defaultEnablePrivacyNotice')->defaultFalse()->setDeprecated('Option was renamed and will be removed in Version 1.0. Use default_display_privacy_notice instead.')->end()
+            ->arrayNode('videoProvider')
+                ->useAttributeAsKey('name')
+                ->setDeprecated('Option was renamed and will be removed in Version 1.0. Use video_provider instead.')
+                ->arrayPrototype()
+                    ->children()
+                        ->scalarNode('class')->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+
+        $rootNode
+            ->children()
+                ->booleanNode('enable_news_support')->defaultFalse()->info('Enable support for news entity. Needs database update after enable.')->end()
+                ->booleanNode('default_use_no_cookie_video_url')->defaultFalse()->info('Enable if by default no cookie embed urls should be used, if supported by the video provider. This can be overwritten on root pages.')->end()
+                ->booleanNode('default_display_privacy_notice')->defaultFalse()->info('Enable if by default a privacy message should be displayed before playing the video. This can be overwritten on root pages.')->end()
+                ->arrayNode('video_provider')
                     ->useAttributeAsKey('name')
                     ->arrayPrototype()
                         ->children()
                             ->scalarNode('class')->end()
-//                            ->arrayNode("configuration")
-//                                ->useAttributeAsKey("name")
-//                                ->defaultValue([])
-//                                ->scalarPrototype()->end()
-//                            ->end()
                         ->end()
                     ->end()
                 ->end()

--- a/src/DependencyInjection/HeimrichHannotVideoExtension.php
+++ b/src/DependencyInjection/HeimrichHannotVideoExtension.php
@@ -24,22 +24,56 @@ class HeimrichHannotVideoExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        if (!isset($config['videoProvider']['youtube'])) {
-            $config['videoProvider']['youtube']['class'] = YouTubeVideo::class;
+        $config = $this->deprecatedOptionsMapping($config);
+
+        if (!isset($config['video_provider']['youtube'])) {
+            $config['video_provider']['youtube']['class'] = YouTubeVideo::class;
         }
 
-        if (!isset($config['videoProvider']['vimeo'])) {
-            $config['videoProvider']['vimeo']['class'] = VimeoVideo::class;
+        if (!isset($config['video_provider']['vimeo'])) {
+            $config['video_provider']['vimeo']['class'] = VimeoVideo::class;
         }
 
-        if (!isset($config['videoProvider']['file'])) {
-            $config['videoProvider']['file']['class'] = FileVideo::class;
+        if (!isset($config['video_provider']['file'])) {
+            $config['video_provider']['file']['class'] = FileVideo::class;
         }
+
+        // Support deperecated option
+        // @todo: remove in version 1.0
+        $config['videoProvider'] = $config['video_provider'];
+
         $container->setParameter('huh_video', $config);
     }
 
     public function getAlias()
     {
         return 'huh_video';
+    }
+
+    /**
+     * Support deprecated options.
+     *
+     * @todo Remove in version 1.0
+     */
+    protected function deprecatedOptionsMapping(array $config): array
+    {
+        if (true === $config['enableNewsSupport'] && true !== $config['enable_news_support']) {
+            $config['enable_news_support'] = true;
+        }
+        $config['enableNewsSupport'] = $config['enable_news_support'];
+
+        if (true === $config['defaultEnableNoCookieVideoUrl'] && true !== $config['default_use_no_cookie_video_url']) {
+            $config['default_use_no_cookie_video_url'] = true;
+        }
+        $config['defaultEnableNoCookieVideoUrl'] = $config['default_use_no_cookie_video_url'];
+
+        if (true === $config['defaultEnablePrivacyNotice'] && true !== $config['default_display_privacy_notice']) {
+            $config['default_display_privacy_notice'] = true;
+        }
+        $config['defaultEnablePrivacyNotice'] = $config['default_display_privacy_notice'];
+
+        $config['video_provider'] = array_merge($config['videoProvider'], $config['video_provider']);
+
+        return $config;
     }
 }

--- a/src/EventListener/LoadDataContainerListener.php
+++ b/src/EventListener/LoadDataContainerListener.php
@@ -57,7 +57,7 @@ class LoadDataContainerListener
 
     protected function prepareNewsTable()
     {
-        if (!isset($this->bundleConfig['enableNewsSupport']) || true !== $this->bundleConfig['enableNewsSupport']) {
+        if (!isset($this->bundleConfig['enable_news_support']) || true !== $this->bundleConfig['enable_news_support']) {
             return;
         }
 

--- a/src/EventListener/ParseArticlesListener.php
+++ b/src/EventListener/ParseArticlesListener.php
@@ -47,7 +47,7 @@ class ParseArticlesListener
      */
     public function onParseArticles(FrontendTemplate $template, array $newsEntry, Module $module): void
     {
-        if (!isset($this->bundleConfig['enableNewsSupport']) || true !== $this->bundleConfig['enableNewsSupport']) {
+        if (!isset($this->bundleConfig['enable_news_support']) || true !== $this->bundleConfig['enable_news_support']) {
             return;
         }
 

--- a/src/Generator/VideoGenerator.php
+++ b/src/Generator/VideoGenerator.php
@@ -223,7 +223,7 @@ class VideoGenerator
     {
         $noCookiesEnabled = false;
 
-        if (isset($this->bundleConfig['defaultEnableNoCookieVideoUrl']) && true === $this->bundleConfig['defaultEnableNoCookieVideoUrl']) {
+        if (isset($this->bundleConfig['default_use_no_cookie_video_url']) && true === $this->bundleConfig['default_use_no_cookie_video_url']) {
             $noCookiesEnabled = true;
         }
 
@@ -238,7 +238,7 @@ class VideoGenerator
     {
         $isPrivacyNoticeEnabled = false;
 
-        if (isset($this->bundleConfig['defaultEnablePrivacyNotice']) && true === $this->bundleConfig['defaultEnablePrivacyNotice']) {
+        if (isset($this->bundleConfig['default_display_privacy_notice']) && true === $this->bundleConfig['default_display_privacy_notice']) {
             $isPrivacyNoticeEnabled = true;
         }
 


### PR DESCRIPTION
This PR renames the configuration options to meet our coding standards. I tried to keep it completely backward compatible. But I wanted to change this before we make this bundle stable.