### PR TITLE
Add vimeo param

### DIFF
--- a/src/Generator/DcaFieldGenerator.php
+++ b/src/Generator/DcaFieldGenerator.php
@@ -276,6 +276,8 @@ class DcaFieldGenerator
             ],
         ];
 
+        $videoFields['vimeo']['sql'] = "varchar(128) NOT NULL default ''";
+
         if (!empty($dca) && !\array_key_exists('posterSRC', $dca['fields'])) {
             $videoFields['posterSRC'] = $GLOBALS['TL_DCA']['tl_content']['fields']['posterSRC'];
         }

--- a/src/Resources/contao/dca/tl_content.php
+++ b/src/Resources/contao/dca/tl_content.php
@@ -25,6 +25,5 @@ $dca['palettes'][\HeimrichHannot\VideoBundle\ContentElement\VideoElement::TYPE] 
  * Fields.
  */
 $arrFields = \HeimrichHannot\VideoBundle\Generator\DcaFieldGenerator::getVideoFields();
-$arrFields['vimeo']['sql'] = "varchar(128) NOT NULL default ''";
 
 $dca['fields'] = array_merge($dca['fields'], $arrFields);

--- a/src/Resources/contao/dca/tl_content.php
+++ b/src/Resources/contao/dca/tl_content.php
@@ -25,5 +25,6 @@ $dca['palettes'][\HeimrichHannot\VideoBundle\ContentElement\VideoElement::TYPE] 
  * Fields.
  */
 $arrFields = \HeimrichHannot\VideoBundle\Generator\DcaFieldGenerator::getVideoFields();
+$arrFields['vimeo']['sql'] = "varchar(128) NOT NULL default ''";
 
 $dca['fields'] = array_merge($dca['fields'], $arrFields);

--- a/src/Video/VimeoVideo.php
+++ b/src/Video/VimeoVideo.php
@@ -104,7 +104,12 @@ class VimeoVideo extends AbstractVideo implements PreviewImageInterface, NoCooki
         }
 
         if (!empty($queryParams)) {
-            $url .= '?'.http_build_query($queryParams);
+            $addParamString = '?';
+            if (false !== stripos($url, '?')) {
+                $addParamString = '&';
+            }
+
+            $url .= $addParamString . http_build_query($queryParams);
         }
 
         return $url;


### PR DESCRIPTION
With the customization it is possible to pass additional Vimeo parameters (e.g. private key) in the input field as well

e.g. for input 855280000?h=310200xxxx to https://player.vimeo.com/video/855280000?h=310200xxxx&dnt=1&autoplay=1